### PR TITLE
rename: update all references from github-app-tools to infra.github.app-creator

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "projectInfo": {
-    "name": "github-app-tools",
+    "name": "infra.github.app-creator",
     "description": "GitHub App creation and management tools",
     "type": "automation"
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This repository provides tools and utilities for creating and managing GitHub Ap
 ### Core Components
 
 ```
-github-app-tools/
+infra.github.app-creator/
 ├── create-app.sh           # Interactive app creation script
 ├── exchange-code.sh        # Standalone credential exchange script
 ├── examples/               # Manifest examples for different use cases
@@ -267,6 +267,7 @@ When working in this repository:
 ## Version History
 
 - **2025-12-03:** Repository migrated to labrats-work organization with fresh history
+- **2026-01-26:** Renamed from github-app-tools to infra.github.app-creator
 - **2025-12-03:** Renamed from my-gh-apps to github-app-tools
 - **Previous:** Basic manifest flow tools, interactive creation script, example manifests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to github-app-tools
+# Contributing to infra.github.app-creator
 
-Thank you for your interest in contributing to the github-app-tools project! This document provides guidelines for contributing.
+Thank you for your interest in contributing to the infra.github.app-creator project! This document provides guidelines for contributing.
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# github-app-tools
+# infra.github.app-creator
 
 Tools and utilities for creating and managing GitHub Apps using the manifest flow.
 
@@ -52,7 +52,7 @@ This will:
 ## Structure
 
 ```
-github-app-tools/
+infra.github.app-creator/
 ├── create-app.sh           # Interactive app creation script
 ├── exchange-code.sh        # Standalone credential exchange script
 ├── examples/               # Manifest examples for different use cases

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Documentation for github-app-tools GitHub App creation tools.
+Documentation for infra.github.app-creator GitHub App creation tools.
 
 ## Quick Links
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: github-app-tools
+site_name: infra.github.app-creator
 site_description: GitHub App creation and management tools
 site_author: labrats-work
-repo_url: https://github.com/labrats-work/github-app-tools
-repo_name: labrats-work/github-app-tools
+repo_url: https://github.com/labrats-work/infra.github.app-creator
+repo_name: labrats-work/infra.github.app-creator
 
 theme:
   name: material

--- a/submit-manifest.html
+++ b/submit-manifest.html
@@ -79,7 +79,7 @@
 
         <div class="step">
             <h3>Then Run:</h3>
-            <code>cd /home/u0/code/labrats-work/github-app-tools<br>./exchange-code.sh YOUR_CODE_HERE</code>
+            <code>cd /home/u0/code/labrats-work/infra.github.app-creator<br>./exchange-code.sh YOUR_CODE_HERE</code>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

- Updated all internal references from `github-app-tools` to `infra.github.app-creator` to match the renamed repository
- Files updated: README.md, CONTRIBUTING.md, CLAUDE.md, mkdocs.yml, docs/README.md, submit-manifest.html, .claude/settings.json
- Added rename history entry in CLAUDE.md version history

🤖 Generated with [Claude Code](https://claude.com/claude-code)