### PR TITLE
feat: add template manifests and Makefile

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "projectInfo": {
-    "name": "github-app-tools",
+    "name": "infra.github.app-creator",
     "description": "GitHub App creation and management tools",
     "type": "automation"
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This repository provides tools and utilities for creating and managing GitHub Ap
 ### Core Components
 
 ```
-github-app-tools/
+infra.github.app-creator/
 ├── create-app.sh           # Interactive app creation script
 ├── exchange-code.sh        # Standalone credential exchange script
 ├── examples/               # Manifest examples for different use cases
@@ -267,6 +267,7 @@ When working in this repository:
 ## Version History
 
 - **2025-12-03:** Repository migrated to labrats-work organization with fresh history
+- **2026-01-26:** Renamed from github-app-tools to infra.github.app-creator
 - **2025-12-03:** Renamed from my-gh-apps to github-app-tools
 - **Previous:** Basic manifest flow tools, interactive creation script, example manifests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to github-app-tools
+# Contributing to infra.github.app-creator
 
-Thank you for your interest in contributing to the github-app-tools project! This document provides guidelines for contributing.
+Thank you for your interest in contributing to the infra.github.app-creator project! This document provides guidelines for contributing.
 
 ## How to Contribute
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,146 @@
+.PHONY: help validate lint list create create-org exchange clean check-deps
+
+MANIFEST ?=
+ORG ?=
+CODE ?=
+
+SHELL := /bin/bash
+SCRIPTS := create-app.sh exchange-code.sh
+EXAMPLES := $(wildcard examples/*.json)
+
+help: ## Show all available targets
+	@echo "infra.github.app-creator"
+	@echo "========================"
+	@echo ""
+	@echo "Usage: make <target> [OPTIONS]"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Options:"
+	@echo "  MANIFEST=<path>    Path to manifest JSON (for create/create-org)"
+	@echo "  ORG=<name>         GitHub organization name (for create-org)"
+	@echo "  CODE=<code>        GitHub manifest code (for exchange)"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make create MANIFEST=examples/ci-automation.json"
+	@echo "  make create-org ORG=labrats-work MANIFEST=examples/ci-automation.json"
+	@echo "  make exchange CODE=01234567-89ab-cdef-0123-456789abcdef"
+
+validate: ## Validate scripts (bash -n) and all example JSONs (jq)
+	@echo "Validating shell scripts..."
+	@fail=0; \
+	for script in $(SCRIPTS); do \
+		if bash -n "$$script"; then \
+			echo "  ✓ $$script"; \
+		else \
+			echo "  ✗ $$script"; \
+			fail=1; \
+		fi; \
+	done; \
+	echo ""; \
+	echo "Validating example manifests..."; \
+	for json in $(EXAMPLES); do \
+		if jq empty "$$json" 2>/dev/null; then \
+			echo "  ✓ $$json"; \
+		else \
+			echo "  ✗ $$json"; \
+			fail=1; \
+		fi; \
+	done; \
+	echo ""; \
+	if [ "$$fail" -eq 1 ]; then \
+		echo "Validation failed."; \
+		exit 1; \
+	else \
+		echo "All validations passed."; \
+	fi
+
+lint: validate ## Alias for validate
+
+list: ## List available template manifests with descriptions
+	@echo "Available template manifests:"
+	@echo ""
+	@for json in $(EXAMPLES); do \
+		name=$$(jq -r '.name' "$$json"); \
+		desc=$$(jq -r '.description' "$$json"); \
+		printf "  %-45s %s\n" "$$json" "$$name"; \
+		echo "    $$desc"; \
+		echo ""; \
+	done
+
+create: ## Create a GitHub App from a manifest (interactive if no MANIFEST given)
+ifeq ($(MANIFEST),)
+	@echo "Available manifests:"; \
+	echo ""; \
+	files=(); \
+	i=1; \
+	for json in $(EXAMPLES); do \
+		name=$$(jq -r '.name' "$$json"); \
+		printf "  %d) %-40s %s\n" "$$i" "$$json" "$$name"; \
+		files+=("$$json"); \
+		i=$$((i + 1)); \
+	done; \
+	echo ""; \
+	read -p "Select manifest [1-$${#files[@]}]: " choice; \
+	idx=$$((choice - 1)); \
+	if [ "$$idx" -lt 0 ] || [ "$$idx" -ge "$${#files[@]}" ]; then \
+		echo "Invalid selection."; \
+		exit 1; \
+	fi; \
+	selected="$${files[$$idx]}"; \
+	echo ""; \
+	./create-app.sh "$$selected"
+else
+	./create-app.sh $(MANIFEST)
+endif
+
+create-org: ## Create an org-level GitHub App (requires ORG and MANIFEST)
+ifeq ($(ORG),)
+	@echo "Error: ORG is required"
+	@echo "Usage: make create-org ORG=<org-name> MANIFEST=<path>"
+	@exit 1
+endif
+ifeq ($(MANIFEST),)
+	@echo "Error: MANIFEST is required"
+	@echo "Usage: make create-org ORG=<org-name> MANIFEST=<path>"
+	@exit 1
+endif
+	./create-app.sh $(MANIFEST) $(ORG)
+
+exchange: ## Exchange a GitHub manifest code for credentials
+ifeq ($(CODE),)
+	@echo "Error: CODE is required"
+	@echo "Usage: make exchange CODE=<code>"
+	@exit 1
+endif
+	./exchange-code.sh $(CODE)
+
+clean: ## Remove generated credentials and temp files
+	@echo "Removing generated credentials and temp files..."
+	@rm -f github-app-private-key.pem
+	@rm -f github-app-credentials.txt
+	@rm -f github-app-*.html
+	@rm -f *.pem
+	@rm -f *.tmp
+	@echo "Done."
+
+check-deps: ## Verify required dependencies (jq, curl, bash) are available
+	@echo "Checking dependencies..."
+	@fail=0; \
+	for cmd in bash curl jq; do \
+		if command -v "$$cmd" > /dev/null 2>&1; then \
+			version=$$($$cmd --version 2>&1 | head -1); \
+			echo "  ✓ $$cmd — $$version"; \
+		else \
+			echo "  ✗ $$cmd — NOT FOUND"; \
+			fail=1; \
+		fi; \
+	done; \
+	echo ""; \
+	if [ "$$fail" -eq 1 ]; then \
+		echo "Missing dependencies. Install them before continuing."; \
+		exit 1; \
+	else \
+		echo "All dependencies available."; \
+	fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# github-app-tools
+# infra.github.app-creator
 
 Tools and utilities for creating and managing GitHub Apps using the manifest flow.
 
@@ -52,7 +52,7 @@ This will:
 ## Structure
 
 ```
-github-app-tools/
+infra.github.app-creator/
 ├── create-app.sh           # Interactive app creation script
 ├── exchange-code.sh        # Standalone credential exchange script
 ├── examples/               # Manifest examples for different use cases

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Documentation for github-app-tools GitHub App creation tools.
+Documentation for infra.github.app-creator GitHub App creation tools.
 
 ## Quick Links
 

--- a/examples/ci-automation.json
+++ b/examples/ci-automation.json
@@ -1,0 +1,23 @@
+{
+  "name": "Labrats-Work CI Automation",
+  "url": "https://github.com/labrats-work/infra.github.app-creator",
+  "description": "CI/CD pipeline bot for labrats-work repositories. Runs checks on pull requests, updates commit statuses, and reads workflow results.",
+  "hook_attributes": {
+    "url": "https://example.com/webhook"
+  },
+  "redirect_url": "https://github.com/labrats-work/infra.github.app-creator",
+  "public": false,
+  "default_permissions": {
+    "contents": "read",
+    "checks": "write",
+    "pull_requests": "write",
+    "actions": "read",
+    "metadata": "read"
+  },
+  "default_events": [
+    "push",
+    "pull_request",
+    "check_run",
+    "check_suite"
+  ]
+}

--- a/examples/code-reviewer.json
+++ b/examples/code-reviewer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Labrats-Work Code Reviewer",
+  "url": "https://github.com/labrats-work/infra.github.app-creator",
+  "description": "Automated PR review bot for labrats-work repositories. Comments on pull requests, posts status checks, and reviews code changes.",
+  "hook_attributes": {
+    "url": "https://example.com/webhook"
+  },
+  "redirect_url": "https://github.com/labrats-work/infra.github.app-creator",
+  "public": false,
+  "default_permissions": {
+    "contents": "read",
+    "pull_requests": "write",
+    "checks": "write",
+    "metadata": "read"
+  },
+  "default_events": [
+    "pull_request",
+    "pull_request_review",
+    "pull_request_review_comment"
+  ]
+}

--- a/examples/release-manager.json
+++ b/examples/release-manager.json
@@ -1,0 +1,21 @@
+{
+  "name": "Labrats-Work Release Manager",
+  "url": "https://github.com/labrats-work/infra.github.app-creator",
+  "description": "Release and deployment automation for labrats-work repositories. Creates releases, manages repository contents, and triggers deployment workflows.",
+  "hook_attributes": {
+    "url": "https://example.com/webhook"
+  },
+  "redirect_url": "https://github.com/labrats-work/infra.github.app-creator",
+  "public": false,
+  "default_permissions": {
+    "contents": "write",
+    "pull_requests": "write",
+    "actions": "write",
+    "metadata": "read"
+  },
+  "default_events": [
+    "push",
+    "pull_request",
+    "release"
+  ]
+}

--- a/examples/repo-admin.json
+++ b/examples/repo-admin.json
@@ -1,0 +1,21 @@
+{
+  "name": "Labrats-Work Repo Admin",
+  "url": "https://github.com/labrats-work/infra.github.app-creator",
+  "description": "Repository administration bot for labrats-work. Manages repository settings, enforces branch protection rules, and tracks issues for policy violations.",
+  "hook_attributes": {
+    "url": "https://example.com/webhook"
+  },
+  "redirect_url": "https://github.com/labrats-work/infra.github.app-creator",
+  "public": false,
+  "default_permissions": {
+    "administration": "write",
+    "contents": "read",
+    "issues": "write",
+    "metadata": "read"
+  },
+  "default_events": [
+    "repository",
+    "branch_protection_rule",
+    "issues"
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: github-app-tools
+site_name: infra.github.app-creator
 site_description: GitHub App creation and management tools
 site_author: labrats-work
-repo_url: https://github.com/labrats-work/github-app-tools
-repo_name: labrats-work/github-app-tools
+repo_url: https://github.com/labrats-work/infra.github.app-creator
+repo_name: labrats-work/infra.github.app-creator
 
 theme:
   name: material

--- a/submit-manifest.html
+++ b/submit-manifest.html
@@ -79,7 +79,7 @@
 
         <div class="step">
             <h3>Then Run:</h3>
-            <code>cd /home/u0/code/labrats-work/github-app-tools<br>./exchange-code.sh YOUR_CODE_HERE</code>
+            <code>cd /home/u0/code/labrats-work/infra.github.app-creator<br>./exchange-code.sh YOUR_CODE_HERE</code>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Add four new example manifests (`ci-automation`, `code-reviewer`, `release-manager`, `repo-admin`) covering common GitHub App patterns referenced in the README
- Add a `Makefile` with targets for validation, listing templates, creating apps, exchanging credentials, dependency checking, and cleanup
- Rename all references from `github-app-tools` to `infra.github.app-creator`

## Test plan
- [ ] `make check-deps` succeeds
- [ ] `make validate` passes (all JSONs valid, scripts pass `bash -n`)
- [ ] `make list` shows all 5 templates with descriptions
- [ ] `make help` shows all targets
- [ ] CI workflow (`validate.yml`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)